### PR TITLE
Return backup's filesize on backup listing

### DIFF
--- a/src/Utility/Backup.php
+++ b/src/Utility/Backup.php
@@ -70,6 +70,9 @@ class Backup
 
         //Parses files
         $files = array_filter(array_map(function ($file) {
+            
+            $filesize = number_format(filesize(BACKUPS . DS . $file) / 1024, 2) . ' kB';
+                
             preg_match('/(\d{14})?\.(sql|sql\.gz|sql\.bz2)$/i', $file, $matches);
 
             if (empty($matches[2])) {
@@ -86,6 +89,7 @@ class Backup
             return (object)[
                 'filename' => $file,
                 'extension' => $matches[2],
+                'filesize' => $filesize,
                 'compression' => getCompression($matches[2]),
                 'datetime' => new \Cake\I18n\FrozenTime($datetime),
             ];


### PR DESCRIPTION
I am using this plugin in my application and I wanted to find out the size of the backups. I made the change and it is working great for me. I wanted to suggest adding it to your plugin, hence this pull request. Thanks for a great job creating this.
